### PR TITLE
Adding me to custom routes in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,7 @@ A handler function receives this arguments:
   - `req` the express.js request object.
   - `res` the express.js response object.
   - `database` is a database object (see above) that you can use for querying the database.
+  - `me` the return of the identify function
 
 ## Limiting results
 


### PR DESCRIPTION
In the documentation at https://github.com/dimitrydhondt/sri4node#custom-routes the argument me isn't described. When peeking in the source code I've seen me is passed to the custom route handler.